### PR TITLE
Add webp as a valid format

### DIFF
--- a/src/enums.py
+++ b/src/enums.py
@@ -9,3 +9,4 @@ class ImageFormat(Enum):
     PNG = "png"
     JPEG = "jpeg"
     JPG = "jpg"
+    WEBP = "webp"


### PR DESCRIPTION
Sometimes the compressed webp output is still not small enough and you gotta compress it again. I've tested this and it works.